### PR TITLE
Remove reviewers and commit-message from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,11 +19,6 @@ updates:
           - "next"
           - "eslint-config-next"
     open-pull-requests-limit: 5
-    reviewers:
-      - "amotarao"
-    commit-message:
-      prefix: "deps"
-      include: "scope"
     ignore:
       - dependency-name: "zod"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Fixes #49

Removed unnecessary `reviewers` and `commit-message` settings from dependabot configuration.

Generated with [Claude Code](https://claude.ai/code)