### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "zod"
+        update-types: ["version-update:semver-major"]
     groups:
       react:
         patterns:
@@ -18,7 +19,3 @@ updates:
         patterns:
           - "next"
           - "eslint-config-next"
-    open-pull-requests-limit: 5
-    ignore:
-      - dependency-name: "zod"
-        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- Remove schedule details (day, time, timezone) to use default weekly schedule
- Increase open-pull-requests-limit from 5 to 10
- Reorganize configuration order for better readability

## Test plan
- [ ] Verify Dependabot continues to work with updated configuration
- [ ] Confirm pull request limit is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)