### PR TITLE
Ignore @types/node major version updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     ignore:
       - dependency-name: "zod"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       react:
         patterns:


### PR DESCRIPTION
## Summary
- Add ignore rule for @types/node major version updates

## Test plan
- [ ] Verify Dependabot respects the ignore rule for @types/node major updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)