### PR TITLE
server.tool() から server.registerTool() に更新

### DIFF
--- a/src/lib/mcp/tools/add-sub-issues.ts
+++ b/src/lib/mcp/tools/add-sub-issues.ts
@@ -6,27 +6,32 @@ export function registerAddSubIssuesTool(
   server: McpServer,
   githubToken?: string,
 ) {
-  server.tool(
+  server.registerTool(
     "add_sub_issues",
-    "Add multiple sub-issues to a GitHub issue using GitHub Sub-Issues API. Supports batch processing for efficiency.",
     {
-      owner: z.string().describe("Repository owner (username or organization)"),
-      repo: z.string().describe("Repository name"),
-      issue_number: z
-        .number()
-        .describe("Parent issue number to add sub-issues to"),
-      sub_issue_ids: z
-        .array(z.number())
-        .describe(
-          "Array of sub-issue IDs to add to the parent issue. These must be internal GitHub issue IDs, not issue numbers.",
-        ),
-      replace_parent: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe(
-          "When true, replaces the current parent issue for each sub-issue",
-        ),
+      description:
+        "Add multiple sub-issues to a GitHub issue using GitHub Sub-Issues API. Supports batch processing for efficiency.",
+      inputSchema: {
+        owner: z
+          .string()
+          .describe("Repository owner (username or organization)"),
+        repo: z.string().describe("Repository name"),
+        issue_number: z
+          .number()
+          .describe("Parent issue number to add sub-issues to"),
+        sub_issue_ids: z
+          .array(z.number())
+          .describe(
+            "Array of sub-issue IDs to add to the parent issue. These must be internal GitHub issue IDs, not issue numbers.",
+          ),
+        replace_parent: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "When true, replaces the current parent issue for each sub-issue",
+          ),
+      },
     },
     async ({ owner, repo, issue_number, sub_issue_ids, replace_parent }) => {
       if (!sub_issue_ids || sub_issue_ids.length === 0) {

--- a/src/lib/mcp/tools/get-id-of-issue.ts
+++ b/src/lib/mcp/tools/get-id-of-issue.ts
@@ -6,13 +6,17 @@ export function registerGetIdOfIssueTool(
   server: McpServer,
   githubToken?: string,
 ) {
-  server.tool(
+  server.registerTool(
     "get_id_of_issue",
-    "Get the internal GitHub issue ID from an issue number",
     {
-      owner: z.string().describe("Repository owner (username or organization)"),
-      repo: z.string().describe("Repository name"),
-      issue_number: z.number().describe("Issue number to get the ID for"),
+      description: "Get the internal GitHub issue ID from an issue number",
+      inputSchema: {
+        owner: z
+          .string()
+          .describe("Repository owner (username or organization)"),
+        repo: z.string().describe("Repository name"),
+        issue_number: z.number().describe("Issue number to get the ID for"),
+      },
     },
     async ({ owner, repo, issue_number }) => {
       try {

--- a/src/lib/mcp/tools/get-ids-of-issues.ts
+++ b/src/lib/mcp/tools/get-ids-of-issues.ts
@@ -6,15 +6,20 @@ export function registerGetIdsOfIssuesTool(
   server: McpServer,
   githubToken?: string,
 ) {
-  server.tool(
+  server.registerTool(
     "get_ids_of_issues",
-    "Get the internal GitHub issue IDs from multiple issue numbers. Supports batch processing for efficiency.",
     {
-      owner: z.string().describe("Repository owner (username or organization)"),
-      repo: z.string().describe("Repository name"),
-      issue_numbers: z
-        .array(z.number())
-        .describe("Array of issue numbers to get the IDs for"),
+      description:
+        "Get the internal GitHub issue IDs from multiple issue numbers. Supports batch processing for efficiency.",
+      inputSchema: {
+        owner: z
+          .string()
+          .describe("Repository owner (username or organization)"),
+        repo: z.string().describe("Repository name"),
+        issue_numbers: z
+          .array(z.number())
+          .describe("Array of issue numbers to get the IDs for"),
+      },
     },
     async ({ owner, repo, issue_numbers }) => {
       if (!issue_numbers || issue_numbers.length === 0) {

--- a/src/lib/mcp/tools/get-parent-of-sub-issue.ts
+++ b/src/lib/mcp/tools/get-parent-of-sub-issue.ts
@@ -6,13 +6,18 @@ export function registerGetParentOfSubIssueTool(
   server: McpServer,
   githubToken?: string,
 ) {
-  server.tool(
+  server.registerTool(
     "get_parent_of_sub_issue",
-    "Get the parent issue of a sub-issue using GitHub Sub-Issues API",
     {
-      owner: z.string().describe("Repository owner (username or organization)"),
-      repo: z.string().describe("Repository name"),
-      issue_number: z.number().describe("Sub-issue number to get parent for"),
+      description:
+        "Get the parent issue of a sub-issue using GitHub Sub-Issues API",
+      inputSchema: {
+        owner: z
+          .string()
+          .describe("Repository owner (username or organization)"),
+        repo: z.string().describe("Repository name"),
+        issue_number: z.number().describe("Sub-issue number to get parent for"),
+      },
     },
     async ({ owner, repo, issue_number }) => {
       try {

--- a/src/lib/mcp/tools/list-sub-issues.ts
+++ b/src/lib/mcp/tools/list-sub-issues.ts
@@ -6,33 +6,38 @@ export function registerListSubIssuesTool(
   server: McpServer,
   githubToken?: string,
 ) {
-  server.tool(
+  server.registerTool(
     "list_sub_issues",
-    "List sub-issues for a GitHub issue with pagination and filtering support",
     {
-      owner: z.string().describe("Repository owner (username or organization)"),
-      repo: z.string().describe("Repository name"),
-      issue_number: z
-        .number()
-        .describe("Parent issue number to list sub-issues for"),
-      per_page: z
-        .number()
-        .optional()
-        .default(30)
-        .describe("Number of results per page (max 100)"),
-      page: z
-        .number()
-        .optional()
-        .default(1)
-        .describe("Page number of results to fetch"),
-      state: z
-        .enum(["open", "closed", "all"])
-        .optional()
-        .describe("Filter sub-issues by state"),
-      labels: z
-        .string()
-        .optional()
-        .describe("Comma-separated list of label names to filter by"),
+      description:
+        "List sub-issues for a GitHub issue with pagination and filtering support",
+      inputSchema: {
+        owner: z
+          .string()
+          .describe("Repository owner (username or organization)"),
+        repo: z.string().describe("Repository name"),
+        issue_number: z
+          .number()
+          .describe("Parent issue number to list sub-issues for"),
+        per_page: z
+          .number()
+          .optional()
+          .default(30)
+          .describe("Number of results per page (max 100)"),
+        page: z
+          .number()
+          .optional()
+          .default(1)
+          .describe("Page number of results to fetch"),
+        state: z
+          .enum(["open", "closed", "all"])
+          .optional()
+          .describe("Filter sub-issues by state"),
+        labels: z
+          .string()
+          .optional()
+          .describe("Comma-separated list of label names to filter by"),
+      },
     },
     async ({ owner, repo, issue_number, per_page, page, state, labels }) => {
       try {

--- a/src/lib/mcp/tools/remove-sub-issues.ts
+++ b/src/lib/mcp/tools/remove-sub-issues.ts
@@ -6,20 +6,25 @@ export function registerRemoveSubIssuesTool(
   server: McpServer,
   githubToken?: string,
 ) {
-  server.tool(
+  server.registerTool(
     "remove_sub_issues",
-    "Remove multiple sub-issues from a GitHub issue using GitHub Sub-Issues API. Supports batch processing for efficiency.",
     {
-      owner: z.string().describe("Repository owner (username or organization)"),
-      repo: z.string().describe("Repository name"),
-      issue_number: z
-        .number()
-        .describe("Parent issue number to remove sub-issues from"),
-      sub_issue_ids: z
-        .array(z.number())
-        .describe(
-          "Array of sub-issue IDs to remove from the parent issue. These must be internal GitHub issue IDs, not issue numbers.",
-        ),
+      description:
+        "Remove multiple sub-issues from a GitHub issue using GitHub Sub-Issues API. Supports batch processing for efficiency.",
+      inputSchema: {
+        owner: z
+          .string()
+          .describe("Repository owner (username or organization)"),
+        repo: z.string().describe("Repository name"),
+        issue_number: z
+          .number()
+          .describe("Parent issue number to remove sub-issues from"),
+        sub_issue_ids: z
+          .array(z.number())
+          .describe(
+            "Array of sub-issue IDs to remove from the parent issue. These must be internal GitHub issue IDs, not issue numbers.",
+          ),
+      },
     },
     async ({ owner, repo, issue_number, sub_issue_ids }) => {
       if (!sub_issue_ids || sub_issue_ids.length === 0) {

--- a/src/lib/mcp/tools/set-milestone-for-issues.ts
+++ b/src/lib/mcp/tools/set-milestone-for-issues.ts
@@ -6,21 +6,26 @@ export function registerSetMilestoneForIssuesTool(
   server: McpServer,
   githubToken?: string,
 ) {
-  server.tool(
+  server.registerTool(
     "set_milestone_for_issues",
-    "Set milestone for multiple GitHub issues. Supports batch processing for efficiency.",
     {
-      owner: z.string().describe("Repository owner (username or organization)"),
-      repo: z.string().describe("Repository name"),
-      issue_numbers: z
-        .array(z.number())
-        .describe("Array of issue numbers to update"),
-      milestone_number: z
-        .number()
-        .nullable()
-        .describe(
-          "Milestone number to set, or null to remove milestone from issues",
-        ),
+      description:
+        "Set milestone for multiple GitHub issues. Supports batch processing for efficiency.",
+      inputSchema: {
+        owner: z
+          .string()
+          .describe("Repository owner (username or organization)"),
+        repo: z.string().describe("Repository name"),
+        issue_numbers: z
+          .array(z.number())
+          .describe("Array of issue numbers to update"),
+        milestone_number: z
+          .number()
+          .nullable()
+          .describe(
+            "Milestone number to set, or null to remove milestone from issues",
+          ),
+      },
     },
     async ({ owner, repo, issue_numbers, milestone_number }) => {
       if (!issue_numbers || issue_numbers.length === 0) {


### PR DESCRIPTION
## Summary
- 全 MCP ツールを `server.tool()` から `server.registerTool()` 形式に変更
- `description` と `inputSchema` を一つのオブジェクトにまとめる形式に統一
- 7つのツールファイルを更新

## Test plan
- [ ] MCP サーバーが正常に起動することを確認
- [ ] 各ツールが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)